### PR TITLE
add Duel.GetShieldCount

### DIFF
--- a/expansions/script/c24004049.lua
+++ b/expansions/script/c24004049.lua
@@ -10,5 +10,5 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.powval(e,c)
-	return Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),c:GetControler(),DM_LOCATION_SHIELD,0,nil)*1000
+	return Duel.GetShieldCount(c:GetControler())*1000
 end

--- a/expansions/script/c24006026.lua
+++ b/expansions/script/c24006026.lua
@@ -8,5 +8,5 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.powval(e,c)
-	return Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),c:GetControler(),DM_LOCATION_SHIELD,0,nil)*2000
+	return Duel.GetShieldCount(c:GetControler())*2000
 end

--- a/expansions/script/c24006027.lua
+++ b/expansions/script/c24006027.lua
@@ -8,9 +8,7 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.tsop(e,tp,eg,ep,ev,re,r,rp)
-	local ct1=Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),tp,DM_LOCATION_SHIELD,0,nil)
-	local ct2=Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),tp,0,DM_LOCATION_SHIELD,nil)
-	if ct2>ct1 then
+	if Duel.GetShieldCount(1-tp)>Duel.GetShieldCount(tp) then
 		Duel.SendDecktoptoShield(tp,1)
 	end
 end

--- a/expansions/script/c24010011.lua
+++ b/expansions/script/c24010011.lua
@@ -8,6 +8,6 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.tscon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),tp,DM_LOCATION_SHIELD,0,nil)>=5
+	return Duel.GetShieldCount(tp)>=5
 end
 scard.tsop=dm.DecktopSendtoShieldOperation(PLAYER_SELF,1)

--- a/expansions/script/c24010047.lua
+++ b/expansions/script/c24010047.lua
@@ -8,6 +8,6 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.dhcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetMatchingGroup(dm.ShieldZoneFilter(),tp,0,DM_LOCATION_SHIELD,nil)<=3
+	return Duel.GetShieldCount(1-tp)<=3
 end
 scard.dhop=dm.DiscardOperation(PLAYER_OPPO,aux.TRUE,0,LOCATION_HAND,1,1,true)

--- a/expansions/script/c24010067.lua
+++ b/expansions/script/c24010067.lua
@@ -8,7 +8,7 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.descon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetMatchingGroup(dm.ShieldZoneFilter(),tp,0,DM_LOCATION_SHIELD,nil)<=2
+	return Duel.GetShieldCount(1-tp)<=2
 end
 function scard.desfilter(c)
 	return c:IsFaceup() and c:IsPowerBelow(3000)

--- a/expansions/script/c24010080.lua
+++ b/expansions/script/c24010080.lua
@@ -8,6 +8,6 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.poscon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),tp,DM_LOCATION_SHIELD,0,nil)>=5
+	return Duel.GetShieldCount(tp)>=5
 end
 scard.posop=dm.UntapOperation(nil,dm.ManaZoneFilter(Card.IsTapped),0,DM_LOCATION_MANA)

--- a/expansions/script/c24010118.lua
+++ b/expansions/script/c24010118.lua
@@ -15,9 +15,8 @@ end
 scard.duel_masters_card=true
 --power up
 function scard.powval(e,c)
-	local ct1=Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),c:GetControler(),DM_LOCATION_SHIELD,0,nil)
-	local ct2=Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),c:GetControler(),0,DM_LOCATION_SHIELD,nil)
-	return (ct1+ct2)*2000
+	local p=c:GetControler()
+	return (Duel.GetShieldCount(p)+Duel.GetShieldCount(1-p))*2000
 end
 --double breaker
 function scard.dbcon(e)

--- a/expansions/script/c24011018.lua
+++ b/expansions/script/c24011018.lua
@@ -8,5 +8,5 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetMatchingGroup(dm.ShieldZoneFilter(),tp,0,DM_LOCATION_SHIELD,nil)<=3
+	return Duel.GetShieldCount(1-tp)<=3
 end

--- a/expansions/script/c24011059.lua
+++ b/expansions/script/c24011059.lua
@@ -8,9 +8,7 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 function scard.thcon(e,tp,eg,ep,ev,re,r,rp)
-	local ct1=Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),tp,DM_LOCATION_SHIELD,0,nil)
-	local ct2=Duel.GetMatchingGroupCount(dm.ShieldZoneFilter(),tp,0,DM_LOCATION_SHIELD,nil)
-	return ct2>ct1
+	return Duel.GetShieldCount(1-tp)>Duel.GetShieldCount(tp)
 end
 function scard.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(DM_LOCATION_SHIELD) and chkc:IsControler(1-tp) and dm.ShieldZoneFilter()(chkc) end

--- a/expansions/utility_dmtcg.lua
+++ b/expansions/utility_dmtcg.lua
@@ -876,6 +876,10 @@ function Duel.GetBlocker()
 	end
 	return Duel.GetFirstMatchingCard(f,0,DM_LOCATION_BATTLE,DM_LOCATION_BATTLE,nil)
 end
+--return the number of shields a player has
+function Duel.GetShieldCount(player)
+	return Duel.GetMatchingGroupCount(Auxiliary.ShieldZoneFilter(),player,DM_LOCATION_SHIELD,0,nil)
+end
 --return the number of shields a player's creatures broke during the current turn
 function Duel.GetBrokenShieldCount(player)
 	return Duel.GetFlagEffect(player,DM_EFFECT_BREAK_SHIELD)
@@ -3586,7 +3590,7 @@ function Auxiliary.NoShieldsCondition(p)
 	return	function(e)
 				local tp=e:GetHandlerPlayer()
 				local player=(p==PLAYER_SELF and tp) or (p==PLAYER_OPPO and 1-tp)
-				return Duel.GetMatchingGroupCount(Auxiliary.ShieldZoneFilter(),player,DM_LOCATION_SHIELD,0,nil)==0
+				return Duel.GetShieldCount(player)==0
 			end
 end
 Auxiliary.nszcon=Auxiliary.NoShieldsCondition


### PR DESCRIPTION
Added `Duel.GetShieldCount` to return the number of shields a player has.