### PR TITLE
fix Vortex Evolution filter

### DIFF
--- a/expansions/script/c24012005.lua
+++ b/expansions/script/c24012005.lua
@@ -20,8 +20,8 @@ end
 scard.duel_masters_card=true
 scard.evolution_race_list={DM_RACE_FIRE_BIRD,DM_RACE_EARTH_DRAGON,DM_RACE_DRAGON}
 --vortex evolution
-scard.evofilter1=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_FIRE_BIRD)
-scard.evofilter2=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_EARTH_DRAGON)
+scard.evofilter1=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_FIRE_BIRD)
+scard.evofilter2=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_EARTH_DRAGON)
 --leave replace (separate evolution source)
 function scard.repop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/expansions/script/c24012057.lua
+++ b/expansions/script/c24012057.lua
@@ -14,5 +14,5 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 scard.evolution_race_list={DM_RACE_LIGHT_BRINGER,DM_RACE_CYBER_LORD,DM_RACE_CYBER}
-scard.evofilter1=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_LIGHT_BRINGER)
-scard.evofilter2=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_CYBER_LORD)
+scard.evofilter1=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_LIGHT_BRINGER)
+scard.evofilter2=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_CYBER_LORD)

--- a/expansions/script/c24012058.lua
+++ b/expansions/script/c24012058.lua
@@ -15,5 +15,5 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 scard.evolution_race_list={DM_RACE_MERFOLK,DM_RACE_CHIMERA}
-scard.evofilter1=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_MERFOLK)
-scard.evofilter2=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_CHIMERA)
+scard.evofilter1=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_MERFOLK)
+scard.evofilter2=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_CHIMERA)

--- a/expansions/script/c24012059.lua
+++ b/expansions/script/c24012059.lua
@@ -19,5 +19,5 @@ function scard.initial_effect(c)
 end
 scard.duel_masters_card=true
 scard.evolution_race_list={DM_RACE_ZOMBIE_DRAGON,DM_RACE_DRAGON,DM_RACE_FIRE_BIRD}
-scard.evofilter1=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_ZOMBIE_DRAGON)
-scard.evofilter2=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_FIRE_BIRD)
+scard.evofilter1=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_ZOMBIE_DRAGON)
+scard.evofilter2=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_FIRE_BIRD)

--- a/expansions/script/c24012060.lua
+++ b/expansions/script/c24012060.lua
@@ -15,8 +15,8 @@ end
 scard.duel_masters_card=true
 scard.evolution_race_list={DM_RACE_HORNED_BEAST,DM_RACE_ANGEL_COMMAND,DM_RACE_COMMAND}
 --vortex evolution
-scard.evofilter1=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_HORNED_BEAST)
-scard.evofilter2=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_ANGEL_COMMAND)
+scard.evofilter1=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_HORNED_BEAST)
+scard.evofilter2=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_ANGEL_COMMAND)
 --to battle or to hand
 function scard.tbop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end

--- a/expansions/script/c24013056.lua
+++ b/expansions/script/c24013056.lua
@@ -17,8 +17,8 @@ end
 scard.duel_masters_card=true
 scard.evolution_race_list={DM_RACE_FIRE_BIRD,DM_RACE_ARMORED_DRAGON,DM_RACE_DRAGON}
 --vortex evolution
-scard.evofilter1=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_FIRE_BIRD)
-scard.evofilter2=aux.FilterBoolFunction(Card.DMIsRace,DM_RACE_ARMORED_DRAGON)
+scard.evofilter1=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_FIRE_BIRD)
+scard.evofilter2=aux.FilterBoolFunction(Card.DMIsEvolutionRace,DM_RACE_ARMORED_DRAGON)
 --get ability (attack untapped)
 function scard.abtg(e,c)
 	return c:DMIsRace(DM_RACE_PHOENIX) or c:DMIsRace(DM_RACE_DRAGON)


### PR DESCRIPTION
Fixed a bug where Innocent Hunter, Blade of All couldn't be used as one of the creatures to evolve for Vortex Evolution.